### PR TITLE
Some implementation improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Gergely Imreh <imrehg@gmail.com>"]
 
 [dependencies]
-byteorder = "^0.4"
 num_cpus = "^0.2"
 rust-crypto = "^0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,18 +2,20 @@
 //!
 //! Calculating the Proof-of-Work function to send messages
 //! from [Bitmessage](https://github.com/Bitmessage/PyBitmessage).
-extern crate byteorder;
+
 extern crate crypto;
 extern crate num_cpus;
 
 use std::sync::mpsc::{Sender, Receiver};
 use std::sync::mpsc;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::thread;
+use std::mem;
 
 use crypto::digest::Digest;
 use crypto::sha2::Sha512;
-use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
-use std::io::Cursor;
 
 /// A single thread of Proof-of-Work calculation
 ///
@@ -23,41 +25,35 @@ use std::io::Cursor;
 ///     trialValue, = unpack('>Q',hashlib.sha512(hashlib.sha512(pack('>Q',nonce) + initialHash).digest()).digest()[0:8])
 ///
 /// This value should be less than or equal to the target
-fn bmpow(target: u64, hash: [u8; 64], starter: u64, stepsize: u64, chan_out: Sender<u64>) {
-    let mut nonce: u64 = starter;
-    let mut algoresult;
-
-    loop {
-        let mut wtr = vec![];
-        let mut result: [u8; 64] = [0; 64];
-        let mut hasher_inner = Sha512::new();
-        let mut hasher_outer = Sha512::new();
-
-        nonce += stepsize;
-        match wtr.write_u64::<BigEndian>(nonce) {
-            Ok(_) => {},
-            Err(e) => { println!("error writing endian: {}", e) },
+fn bmpow(target: u64, hash: &[u8; 64], starter: u64, stepsize: u64, cancelled: &AtomicBool) -> u64 {
+    for i in 0.. {
+        if cancelled.load(Relaxed) {
+            return 0;
         }
-        hasher_inner.input(&wtr);
-        hasher_inner.input(&hash);
-
-        hasher_inner.result(&mut result);
-        hasher_outer.input(&result);
-
-        let mut result_outer: [u8; 64] = [0; 64];
-        hasher_outer.result(&mut result_outer);
-
-        let mut r2 = vec![0; 64];
-        hasher_outer.result(&mut r2);
-        let mut rdr = Cursor::new(r2);
-        // Converting from BigEndian to the endinannes of the system
-        algoresult = rdr.read_u64::<BigEndian>().unwrap();
-        if algoresult < target {
-            chan_out.send(nonce).unwrap();
-            return;
+        let nonce = starter + i * stepsize;
+        if hash_nonce(nonce, &hash) < target {
+            return nonce;
         }
     }
+    unreachable!();
 }
+
+fn hash_nonce(nonce: u64, hash: &[u8; 64]) -> u64 {
+    let nonce_bytes: [u8; 8] = unsafe {mem::transmute(nonce.to_be())};
+    let mut hasher = Sha512::new();
+    let mut hash_result = [0u8; 64];
+    // hash (nonce + hash)
+    hasher.input(&nonce_bytes);
+    hasher.input(hash);
+    hasher.result(&mut hash_result);
+    hasher.reset();
+    // hash result
+    hasher.input(&hash_result);
+    hasher.result(&mut hash_result);
+    let result: &u64 = unsafe {mem::transmute(&hash_result)};
+    u64::from_be(*result)
+}
+
 
 /// The exported Proof-of-Work task
 ///
@@ -88,21 +84,23 @@ pub extern fn runpow(target: u64, hash: &[u8; 64]) -> u64 {
 
     let threads = num_cpus::get() as u64;
 
-    // Copy them input
-    let mut h: [u8; 64] = [0; 64];
-    for (i, b) in hash.iter().enumerate() {
-        h[i] = *b;
-    }
+    let hash = *hash;
+    // allow threads to be cancelled, so they don't continue computation 
+    let cancelled = Arc::new(AtomicBool::new(false));
 
     // Start computation
     for i in 0..threads {
         let tx = tx.clone();
+        let cancelled = cancelled.clone();
         thread::spawn(move || {
-            bmpow(target, h, i, threads, tx);
+            let result = bmpow(target, &hash, i, threads, &cancelled);
+            // If the channel is closed, don't panic
+            let _ = tx.send(result);
         });
     }
 
     // Wait until one of the threads tumbles on a good nonce
     let value = rx.recv().unwrap();
+    cancelled.store(true, Relaxed);
     value
 }


### PR DESCRIPTION
- Avoid heap allocations when possible
- Refactor out a function to calculate the u64 hash value from a nonce
- When a value is returned, cancel the other threads, so they don't each
  continue to try to find a solution
